### PR TITLE
Add activation of parameter by name

### DIFF
--- a/src/main/java/parameter_service_demo/controller/ExceptionHandlingAdvice.java
+++ b/src/main/java/parameter_service_demo/controller/ExceptionHandlingAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import parameter_service_demo.dto.ErrorDto;
 import parameter_service_demo.dto.ValidationErrorDto;
 import parameter_service_demo.exception.EntityNotFoundException;
+import parameter_service_demo.exception.ImmutableParameterChangeException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,7 +28,7 @@ public class ExceptionHandlingAdvice {
         return buildErrorResponse(HttpStatus.NOT_FOUND, request.getRequestURI(), e.getMessage());
     }
 
-    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
+    @ExceptionHandler({HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class, ImmutableParameterChangeException.class})
     public ResponseEntity<ErrorDto> handleBadRequestException(Exception e, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, request.getRequestURI(), e.getMessage());
     }

--- a/src/main/java/parameter_service_demo/controller/ParameterController.java
+++ b/src/main/java/parameter_service_demo/controller/ParameterController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -23,6 +24,9 @@ import parameter_service_demo.dto.NewParameterDto;
 import parameter_service_demo.dto.ParameterDto;
 import parameter_service_demo.dto.ValidationErrorDto;
 import parameter_service_demo.service.ParameterService;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -97,5 +101,17 @@ public class ParameterController {
     )
     public void deleteParameterById(@PathVariable Long id) {
         parameterService.deleteById(id);
+    }
+
+    @PostMapping("activate/{name}")
+    @Operation(summary = "Activates (locks) a parameter with ID provided in the path.")
+    @ApiResponse(responseCode = "200", description = "Parameter activated successfully.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Parameter is already activated.",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))
+    )
+    public List<ParameterDto> activateByName(@PathVariable String name, @RequestParam LocalDate activationDate) {
+        return parameterService.activateByName(name, activationDate);
     }
 }

--- a/src/main/java/parameter_service_demo/dto/ParameterDto.java
+++ b/src/main/java/parameter_service_demo/dto/ParameterDto.java
@@ -1,10 +1,13 @@
 package parameter_service_demo.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor
@@ -21,4 +24,11 @@ public class ParameterDto {
 
     @Schema(description = "The value of the parameter.")
     private String value;
+
+    @Schema(description = "Is the parameter activated or not.")
+    private ParameterStatus status;
+
+    @Nullable
+    @Schema(description = "If parameter is activated, this will be the activation date, otherwise null.")
+    private LocalDate activeFrom;
 }

--- a/src/main/java/parameter_service_demo/dto/ParameterStatus.java
+++ b/src/main/java/parameter_service_demo/dto/ParameterStatus.java
@@ -1,0 +1,6 @@
+package parameter_service_demo.dto;
+
+public enum ParameterStatus {
+    DRAFT,
+    ACTIVE
+}

--- a/src/main/java/parameter_service_demo/exception/ImmutableParameterChangeException.java
+++ b/src/main/java/parameter_service_demo/exception/ImmutableParameterChangeException.java
@@ -1,0 +1,8 @@
+package parameter_service_demo.exception;
+
+public class ImmutableParameterChangeException extends RuntimeException {
+
+    public ImmutableParameterChangeException(Long id) {
+        super("Parameter with id %d is activated and immutable".formatted(id));
+    }
+}

--- a/src/main/java/parameter_service_demo/model/ParameterEntity.java
+++ b/src/main/java/parameter_service_demo/model/ParameterEntity.java
@@ -9,6 +9,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.time.LocalDate;
+
 @Setter
 @Getter
 @Table("parameter")
@@ -26,4 +28,11 @@ public class ParameterEntity {
 
     @Column("value_")
     private String value;
+
+    @Column("active_from")
+    private LocalDate activeFrom;
+
+    public boolean isActive() {
+        return activeFrom != null;
+    }
 }

--- a/src/main/java/parameter_service_demo/repository/ParameterRepository.java
+++ b/src/main/java/parameter_service_demo/repository/ParameterRepository.java
@@ -1,8 +1,15 @@
 package parameter_service_demo.repository;
 
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.stereotype.Repository;
 import parameter_service_demo.model.ParameterEntity;
 
+import java.util.List;
+
 @Repository
-public interface ParameterRepository extends ListCrudRepository<ParameterEntity, Long> {}
+public interface ParameterRepository extends ListCrudRepository<ParameterEntity, Long> {
+
+    @Query("select * from \"parameter\" where \"name\" = :name")
+    List<ParameterEntity> findByName(String name);
+}

--- a/src/main/java/parameter_service_demo/service/ParameterService.java
+++ b/src/main/java/parameter_service_demo/service/ParameterService.java
@@ -5,9 +5,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import parameter_service_demo.dto.NewParameterDto;
 import parameter_service_demo.dto.ParameterDto;
+import parameter_service_demo.dto.ParameterStatus;
 import parameter_service_demo.exception.EntityNotFoundException;
+import parameter_service_demo.exception.ImmutableParameterChangeException;
 import parameter_service_demo.model.ParameterEntity;
 import parameter_service_demo.repository.ParameterRepository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,15 +36,43 @@ public class ParameterService {
         if (!parameterRepository.existsById(id)) {
             throw new EntityNotFoundException("Parameter", id);
         }
+        validateActive(id);
 
         var parameterEntity = newParameterDtoToEntity(newParameterDto);
         parameterEntity.setId(id);
         return parameterEntityToDto(parameterRepository.save(parameterEntity));
     }
 
+    public List<ParameterDto> activateByName(String name, LocalDate activationDate) {
+        return activate(name, activationDate).stream().map(this::parameterEntityToDto).toList();
+    }
+
     @Transactional
     public void deleteById(Long id) {
+        validateActive(id);
         parameterRepository.deleteById(id);
+    }
+
+    @Transactional
+    protected List<ParameterEntity> activate(String name, LocalDate activationDate) {
+        var parameterEntities = parameterRepository.findByName(name);
+
+        for (var parameterEntity : parameterEntities) {
+            if (parameterEntity.isActive()) {
+                throw new ImmutableParameterChangeException(parameterEntity.getId());
+            }
+            parameterEntity.setActiveFrom(activationDate);
+        }
+
+        return parameterRepository.saveAll(parameterEntities);
+    }
+
+    private void validateActive(Long id) {
+        parameterRepository.findById(id).ifPresent(parameterEntity -> {
+            if (parameterEntity.isActive()) {
+                throw new ImmutableParameterChangeException(id);
+            }
+        });
     }
 
     private ParameterEntity newParameterDtoToEntity(NewParameterDto newParameterDto) {
@@ -54,6 +87,8 @@ public class ParameterService {
                 .id(parameterEntity.getId())
                 .name(parameterEntity.getName())
                 .value(parameterEntity.getValue())
+                .status(parameterEntity.isActive() ? ParameterStatus.ACTIVE : ParameterStatus.DRAFT)
+                .activeFrom(parameterEntity.getActiveFrom())
                 .build();
     }
 }

--- a/src/main/resources/migration/V2__add_activation_date.sql
+++ b/src/main/resources/migration/V2__add_activation_date.sql
@@ -1,0 +1,2 @@
+alter table "parameter"
+    add "active_from" date;


### PR DESCRIPTION
In scope of this pull request we add a feature of activation of parameter by name.
You can call additional endpoint `/parameter/activate/{name}` to set the activation date for all the parameters with given name. This will lock the activated parameters and they could not be updated or deleted anymore.